### PR TITLE
remove deprecated beta prefixes

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -29,7 +29,7 @@ def tabular_bias():
     
     st.markdown("""---""")
     
-    col1, col2, col3, col4 = st.beta_columns(4)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         help.sub_text("""<b>Keywords</b>""", 
@@ -68,7 +68,7 @@ def tabular_bias():
         
     st.markdown("""---""")
         
-    expander = st.beta_expander('Data Understanding', 
+    expander = st.expander('Data Understanding', 
                                 expanded=False)
 
     with expander:
@@ -128,7 +128,7 @@ def tabular_bias():
                 st.pyplot()
     
     
-    expander = st.beta_expander('Data Preparation', 
+    expander = st.expander('Data Preparation', 
                                 expanded=False)
 
     with expander:
@@ -217,7 +217,7 @@ def tabular_bias():
                 
                 
 
-    expander = st.beta_expander('Model Development', 
+    expander = st.expander('Model Development', 
                                 expanded=False)
 
     with expander:
@@ -301,7 +301,7 @@ def text_bias():
     
     st.markdown("""---""")
     
-    col1, col2, col3, col4 = st.beta_columns(4)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         help.sub_text("""<b>Keywords</b>""", 
@@ -339,7 +339,7 @@ def text_bias():
         
     st.markdown("""---""")
     
-    expander = st.beta_expander('Data Understading', 
+    expander = st.expander('Data Understading', 
                                 expanded=False)
 
     with expander:
@@ -356,7 +356,7 @@ def text_bias():
         
         help.sub_text(exp_text)
         
-    expander = st.beta_expander('Responsibly Example', 
+    expander = st.expander('Responsibly Example', 
                                 expanded=False)
 
     with expander:
@@ -495,7 +495,7 @@ def tabular_xai():
     
     st.markdown("""---""")
     
-    col1, col2, col3, col4 = st.beta_columns(4)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         help.sub_text("""<b>Keywords</b>""", 
@@ -528,7 +528,7 @@ def tabular_xai():
         
     st.markdown("""---""")
     
-    expander = st.beta_expander('Data Understanding', 
+    expander = st.expander('Data Understanding', 
                                 expanded=False)
 
     with expander:
@@ -543,7 +543,7 @@ def tabular_xai():
     
     
     
-    expander = st.beta_expander('Model Development and Evaluation', 
+    expander = st.expander('Model Development and Evaluation', 
                                 expanded=False)
     
     with expander:
@@ -672,7 +672,7 @@ def image_xai():
     
     st.markdown("""---""")
     
-    col1, col2, col3, col4 = st.beta_columns(4)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         help.sub_text("""<b>Keywords</b>""", 
@@ -707,7 +707,7 @@ def image_xai():
         
     st.markdown("""---""")
     
-    expander = st.beta_expander('NBDT Example', 
+    expander = st.expander('NBDT Example', 
                                 expanded=False)
 
     with expander:
@@ -735,7 +735,7 @@ With this approach, the accuracy of a neural net is preserved.">
         st.video("https://youtu.be/cSeAhiZB8SI")
         
     
-    expander = st.beta_expander('Lime Example', 
+    expander = st.expander('Lime Example', 
                                 expanded=False)
     
     with expander:
@@ -850,7 +850,7 @@ def text_xai():
     
     st.markdown("""---""")
     
-    col1, col2, col3, col4 = st.beta_columns(4)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         help.sub_text("""<b>Keywords</b>""", 
@@ -883,7 +883,7 @@ def text_xai():
         
     st.markdown("""---""")
     
-    expander = st.beta_expander('LIME Explanation Example', 
+    expander = st.expander('LIME Explanation Example', 
                                 expanded=False)
 
     with expander:
@@ -1081,7 +1081,7 @@ def dvc_data():
 
     help.expander('DVC', intro)
 
-    expander = st.beta_expander('DVC Example', 
+    expander = st.expander('DVC Example', 
                                 expanded=False)
 
     with expander:

--- a/helper.py
+++ b/helper.py
@@ -98,7 +98,7 @@ def expander(expander_title,
 
     '''
     
-    expander = st.beta_expander(expander_title, expanded=False)
+    expander = st.expander(expander_title, expanded=False)
     
     with expander:
         


### PR DESCRIPTION
Some function calls had a 'beta_' prefix, which led to deprecation warnings. This PR removes those prefixes